### PR TITLE
moves overview to readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,15 +2,15 @@
 
 The **companion application** is an example to
 showcase how to create a vehicle application which senses and actuates signals in the vehicle
-for Eclipse Leda with help of Eclipse Velocitas and Eclipse Kuksa
+for Eclipse Leda with the help of Eclipse Velocitas and Eclipse Kuksa
 . The aim is not to build the best available application possible but to show how one can use the applied technologies
-to build a companion app for the interaction with a vehicle, e.g., to move a seat.
+to build a companion application for the interaction with a vehicle, e.g., to move a seat.
 If you are new to the concepts around Eclipse SDV and the mentioned projects
 we recommend to read the [SDV Tutorial](https://eclipse-leda.github.io/leda/docs/general-usage/sdv-introduction/) first.
 
 ## Description
 
-The idea of the specific companion application introduced in this blueprint is to have a custom application to move the driver seat to positions defined
+The idea of the specific companion application introduced in this blueprint is to move the driver seat to positions defined
 in a driver profile hosted by a third-party web service.
 
 ![Leda Seat Adjuster Use Case](./img/seatadjuster.png)
@@ -22,8 +22,17 @@ The setup contains the following components:
 - Eclipse Kuksa.val - **KUKSA Databroker** (pre-installed with Eclipse Leda)
 - **Mock Service**: Example provider for Eclipse Kuksa.VAL which mocks the behavior of the vehicle.
 
-In the following paragraphs, we next introduce the [architecture and the assumed data flow](./architecture-seat-adjuster.md)
-before we explain the [development](./develop-seat-adjuster.md) and [deployment](./deploy-seat-adjuster.md) steps.
-If you are more interested in the general development steps, you may directly jump to the [develop seat adjuster](./develop-seat-adjuster.md).
+In the following pages, we first introduce the [architecture and the assumed data flow](./architecture-seat-adjuster.md) in more detail.
+
+We then show how to realize the introduced architecture with Eclipse Velocitas and Eclipse Leda 0.1.0-M2. On a high level, you will perform the following steps and we describe each step in more detail in this guide. So simply [continue reading](./architecture-seat-adjuster.md):
+
+1. [Setup the Eclipse Velocitas template repository](./develop-seat-adjuster.md#setup-eclipse-velocitas-from-template-repository) to develop, build and deploy your
+version of the seat adjuster example in a VSCode DevContainer.
+
+2. [Run Eclipse Leda](./deploy-seat-adjuster.md), for example, as container or with other options like QEMU, physical hardware, etc.
+
+3. [Manage the Eclipse Kanto container runtime](./deploy-seat-adjuster.md) in Eclipse Leda to deploy your seat adjuster application.
+
+4. [Test the deployed setup](./interact-seat-adjuster.md) in Eclipse Leda by interacting with the seat adjuster over MQTT to change the seat position.
 
 If you run into any issues while following this guide, you can check the [troubleshooting page](./troubleshooting.md) for possible hints.

--- a/develop-seat-adjuster.md
+++ b/develop-seat-adjuster.md
@@ -1,17 +1,6 @@
 # Develop Application
 
-The following pages show how to execute the explained setup using Eclipse Velocitas and Eclipse Leda 0.1.0-M2:
-
-On a high level, you need to perform the following steps described in more detail in this guide:
-
-1. Use the Eclipse Velocitas template repository to develop, build and deploy your
-version of the [seat adjuster example](https://github.com/eclipse-velocitas/vehicle-app-python-sdk/tree/main/examples/seat-adjuster).
-
-2. Run Eclipse Leda, for example, [as container](https://eclipse-leda.github.io/leda/docs/general-usage/docker-setup/) or with other options like [QEMU, physical hardware, etc.](https://eclipse-leda.github.io/leda/docs/general-usage/).
-
-3. [Manage the Eclipse Kanto container runtime](./deploy-seat-adjuster.md) to deploy your seat adjuster application.
-
-4. [Test the deployed setup](./interact-seat-adjuster.md) by interacting with the seat adjuster to change the seat position.
+After we established [the architecture](./architecture-seat-adjuster.md) of what we want to build, it is time to develop the application with the help of the Eclipse Velocitas DevContainer and templates.
 
 ## Setup Eclipse Velocitas from template repository
 


### PR DESCRIPTION
This moves the high level overview from the development page to the first page (Readme.md). In addition, I removed some external references to avoid that the reader gets diverted by leaving the guided tour in this guide too early. 

This relates to #11 